### PR TITLE
docs: fix install instructions for the published package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ coverage.db
 __pycache__/
 .venv/
 venv/
+runtime/
 dist/
 benchmark_dataset_*.json
 

--- a/README.md
+++ b/README.md
@@ -21,17 +21,17 @@ Prerequisites:
 **To use Shikhu on your own codebase** — install it as a standalone tool, then run it from inside any repo:
 
 ```bash
-uv tool install git+https://github.com/arjunpatel7/shikhu.git
+uv tool install shikhu
 ```
 
-This puts `shikhu` on your `PATH` in an isolated environment (no clash with your project's dependencies). `cd` into any repo and the commands below just work — each repo gets its own `coverage.db`, `.quizignore`, and `.env`. (`pipx install git+…` or `pip install git+…` into a virtualenv work too.)
+This puts `shikhu` on your `PATH` in an isolated environment (no clash with your project's dependencies). `cd` into any repo and the commands below just work — each repo gets its own `coverage.db`, `.quizignore`, and `.env`. (`pipx install shikhu` or `pip install shikhu` into a virtualenv work too.)
 
-Provide your Mercury API key via a `.env` file in the repo you're quizzing (auto-loaded), or export it in your shell:
+Provide your Inception API key via a `.env` file in the repo you're quizzing (auto-loaded), or export it in your shell:
 ```
 INCEPTION_API_KEY=your-key-here
 ```
 
-Get a key at [Inception Labs](https://www.inceptionlabs.ai/).
+Get a key at [Inception Labs](https://platform.inceptionlabs.ai/).
 
 
 ### 2. Initialize

--- a/src/shikhu/commands/study_context.py
+++ b/src/shikhu/commands/study_context.py
@@ -24,7 +24,7 @@ def study_context(
     console.print(f"[bold]=== Summary for {file_path} ===[/bold]")
     if summary is None:
         console.print("[yellow]No cached summary.[/yellow]")
-        console.print(f"Run: [cyan]uv run shikhu summarize --file {file_path}[/cyan]")
+        console.print(f"Run: [cyan]shikhu summarize --file {file_path}[/cyan]")
     else:
         console.print(
             f"[dim](prompt {summary['prompt_version']}, generated {summary['generated_at']})[/dim]"


### PR DESCRIPTION
## Summary
Corrects install details now that `shikhu` is live on PyPI.

- **Install command** → `uv tool install shikhu` (was `git+https://…/shikhu.git`); pip/pipx alternatives use the PyPI name too
- **Inception link** → the canonical key page `https://platform.inceptionlabs.ai/`, and the wording is "Inception API key" consistently (matches `INCEPTION_API_KEY`)
- **CLI hint fix** → `study_context` printed `uv run shikhu summarize …`, which fails for an installed tool; now `shikhu summarize …`
- gitignore the local `runtime/` dev venv

## Test plan
- 88 tests pass; ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)