### PR TITLE
fix: load_dotenv() ignores cwd when run from installed package

### DIFF
--- a/src/shikhu/commands/generate_from_study.py
+++ b/src/shikhu/commands/generate_from_study.py
@@ -1,7 +1,7 @@
 """shikhu generate-from-study — produce quiz questions seeded by the user's prior /shikhu-study questions for a file."""
 
 import typer
-from dotenv import load_dotenv
+from dotenv import find_dotenv, load_dotenv
 
 from shikhu.commands.utils import console, ensure_api_key
 from shikhu.ingest import ingest_recent
@@ -17,7 +17,7 @@ def generate_from_study(
     """Generate quiz questions for FILE_PATH seeded by conceptual questions the user asked during prior /shikhu-study sessions on this file.
 
     Manual trigger only. Run `/shikhu-study <file>` first to capture seed questions; this command then turns those questions into quiz questions that test the same concepts."""
-    load_dotenv()
+    load_dotenv(find_dotenv(usecwd=True))
     ensure_api_key()
     init_db()
     try:

--- a/src/shikhu/commands/init.py
+++ b/src/shikhu/commands/init.py
@@ -4,7 +4,7 @@ import os
 from pathlib import Path
 
 import typer
-from dotenv import load_dotenv
+from dotenv import find_dotenv, load_dotenv
 
 from shikhu.commands.install_skill import SKILL_NAME, install_skill_files
 from shikhu.commands.utils import console
@@ -17,7 +17,9 @@ def init(
     ),
 ):
     """Set up Shikhu: create DB, check API keys, generate .quizignore."""
-    load_dotenv()
+    # find_dotenv(usecwd=True): load_dotenv() otherwise searches upward from this
+    # installed package's own file location, not the user's working directory.
+    load_dotenv(find_dotenv(usecwd=True))
 
     console.print()
     console.print("[bold]Shikhu[/bold] — knowledge coverage for your codebase")

--- a/src/shikhu/commands/refresh.py
+++ b/src/shikhu/commands/refresh.py
@@ -3,7 +3,7 @@
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import typer
-from dotenv import load_dotenv
+from dotenv import find_dotenv, load_dotenv
 from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
 
 from shikhu.commands.summarize import _summarize_one
@@ -26,7 +26,7 @@ def refresh(
     ),
 ):
     """Check staleness, regenerate questions + summaries, print summary."""
-    load_dotenv()
+    load_dotenv(find_dotenv(usecwd=True))
     ensure_api_key()
     init_db()
     try:

--- a/src/shikhu/generator.py
+++ b/src/shikhu/generator.py
@@ -7,13 +7,15 @@ import tomllib
 from pathlib import Path
 
 import requests
-from dotenv import load_dotenv
+from dotenv import find_dotenv, load_dotenv
 from pydantic import BaseModel, Field
 
 from shikhu.store import read_file_lines
 
 # Load .env at import so INCEPTION_API_KEY is present before any request is made.
-load_dotenv()
+# find_dotenv(usecwd=True): load_dotenv() otherwise searches upward from this
+# installed package's own file location, not the user's working directory.
+load_dotenv(find_dotenv(usecwd=True))
 
 REQUEST_TIMEOUT = 120  # seconds — one hung connection must not stall a whole refresh
 


### PR DESCRIPTION
## Summary
- `load_dotenv()` defaults to `usecwd=False`, so when called from installed package code it searches upward from the calling file's location (site-packages) instead of the user's working directory, silently missing `.env` — `shikhu init` reported the API key as missing even when `.env` was present in the project.
- Switched all four call sites (`init.py`, `generator.py`, `refresh.py`, `generate_from_study.py`) to `load_dotenv(find_dotenv(usecwd=True))`.

## Test plan
- [x] Reinstalled via `uv tool install --force -e .` and confirmed `shikhu init` now reports "API key found"
- [x] `ruff check src/` passes
- [x] `pytest` (98 passed)
- [x] Ran `vet` locally against `main` — only flagged pre-existing untracked files unrelated to this diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)